### PR TITLE
docs(sdk): add SetMatchWinTeam to all integration docs

### DIFF
--- a/3-Extra/c-integration.md
+++ b/3-Extra/c-integration.md
@@ -76,6 +76,12 @@ int result = SendSpawnAction(baseData, characterGuid, strlen(characterGuid),
                              position, rotation);
 ```
 
+Set the winning team for a match (optional, must be called before MarkEndGame):
+
+```c
+int success = SetMatchWinTeam(matchGuid, matchGuidSize, teamGuid, teamGuidSize);
+```
+
 End a game (All Game's Matches will close as well):
 
 ```c
@@ -137,6 +143,20 @@ int matchGuidSize = StartMatch(matchInfo, matchGuidOut);
   * `matchMode` - the mode of the match (each mode has an additional AI learning processes) - String, Alphanumeric, max 36 chars.
   * `mapName` - the unique name of the map - String, Alphanumeric, max 36 chars.
 * `matchGuidOut` - A pre-allocated char array to store the output match guid (should be at least 37 bytes).
+
+### SetMatchWinTeam(const char* matchGuid, int matchGuidSize, const char* teamGuid, int teamGuidSize)
+
+Sets the winning team for a match. This is optional, but must be called before `MarkEndGame`.
+
+```c
+int success = SetMatchWinTeam(matchGuid, matchGuidSize, teamGuid, teamGuidSize);
+```
+* `matchGuid` - The Match guid you received when starting a new Match
+* `matchGuidSize` - The size of the match guid
+* `teamGuid` - The guid of the winning team
+* `teamGuidSize` - The size of the team guid
+
+`SetMatchWinTeam` returns 1 if the winning team was successfully set, 0 otherwise.
 
 ### MarkEndGame(const char* gameGuid, int guidSize)
 

--- a/3-Extra/csharp-integration.md
+++ b/3-Extra/csharp-integration.md
@@ -74,6 +74,12 @@ GetgudSDK.SendSpawnActionInfo spawnInfo = new GetgudSDK.SendSpawnActionInfo
 int result = GetgudSDK.Methods.SendSpawnAction(spawnInfo);
 ```
 
+Set the winning team for a match (optional, must be called before MarkEndGame):
+
+```csharp
+int result = GetgudSDK.Methods.SetMatchWinTeam(matchGuid, teamGuid);
+```
+
 End a game (All Game's Matches will close as well):
 
 ```csharp
@@ -135,6 +141,21 @@ static public int StartMatch(StartMatchInfo info, out string matchGuidOut);
   * `matchMode` - the mode of the match (each mode has an additional AI learning processes) - String, Alphanumeric, max 36 chars.
   * `mapName` - the unique name of the map - String, Alphanumeric, max 36 chars.
 * `matchGuidOut` - An output parameter to store the match guid.
+
+### SetMatchWinTeam(string matchGuid, string teamGuid)
+
+Sets the winning team for a match. This is optional, but must be called before `MarkEndGame`.
+
+```csharp
+static public int SetMatchWinTeam(string matchGuid, string teamGuid);
+
+// Usage:
+int result = GetgudSDK.Methods.SetMatchWinTeam(matchGuid, teamGuid);
+```
+* `matchGuid` - The Match guid you received when starting a new Match
+* `teamGuid` - The guid of the winning team
+
+`SetMatchWinTeam` returns an integer indicating success (1) or failure (0).
 
 ### MarkEndGame(string gameGuid)
 

--- a/3-Extra/python-integration.md
+++ b/3-Extra/python-integration.md
@@ -64,6 +64,12 @@ sdk.send_spawn_action(
 )
 ```
 
+Set the winning team for a match (optional, must be called before mark_end_game):
+
+```python
+result = sdk.set_match_win_team(match_guid, team_guid)
+```
+
 End a game (All Game's Matches will close as well):
 
 ```python
@@ -123,6 +129,22 @@ Parameters:
 
 Returns:
 - `match_guid` (str) - The unique identifier for the match.
+
+### set_match_win_team(match_guid, team_guid)
+
+Sets the winning team for a match. This is optional, but must be called before `mark_end_game`.
+
+Parameters:
+- `match_guid` (str) - The unique identifier for the match.
+- `team_guid` (str) - The unique identifier of the winning team.
+
+Returns:
+- `result` (int) - The result of the operation (1 for success, 0 for failure).
+
+Example:
+```python
+result = sdk.set_match_win_team(match_guid, team_guid)
+```
 
 ### mark_end_game(game_guid)
 

--- a/sdk-commands.md
+++ b/sdk-commands.md
@@ -76,6 +76,12 @@ for (auto* sentAction : actionsToSend)
 actionsToSend.clear();
 ```
 
+Set the winning team for a match (optional, must be called before MarkEndGame):
+
+```cpp
+bool success = GetgudSDK::SetMatchWinTeam(matchGuid, teamGuid);
+```
+
 End a game (All Game's Matches will close as well):
 
 ```cpp
@@ -162,6 +168,18 @@ This is an async method which will not block the calling thread.
 bool SendAction(BaseActionData* action);
 ```
 * `action` - a `BaseActionData` object that is the base class of all the primal 7 actions (Spawn, Position, Attack, Damage, Heal, Affect and Death).
+
+### SetMatchWinTeam(matchGuid, teamGuid)
+
+Sets the winning team for a match. This is optional, but must be called before `MarkEndGame`.
+
+```cpp
+bool success = GetgudSDK::SetMatchWinTeam(matchGuid, teamGuid);
+```
+* `matchGuid` - The Match guid you received when starting a new Match
+* `teamGuid` - The guid of the winning team
+
+`SetMatchWinTeam` returns true/false depending on if the winning team was successfully set or not.
 
 ### MarkEndGame(gameGuid)
 


### PR DESCRIPTION
## Summary
- Added `SetMatchWinTeam` / `set_match_win_team` documentation to `sdk-commands.md`, `c-integration.md`, `csharp-integration.md`, and `python-integration.md`
- Added both API reference sections and quick-start snippets, noting it's optional and must be called before `MarkEndGame`

🤖 Generated with [Claude Code](https://claude.com/claude-code)