### PR TITLE
chore(docs): replace staging API URLs with production

### DIFF
--- a/1-Integrations/Unity/unity-integration.md
+++ b/1-Integrations/Unity/unity-integration.md
@@ -27,10 +27,10 @@ Create a Getgud `config.json` file in the `Server/` folder with the following co
 
 ```json
 {
-  "streamGameURL": "https://api.staging.getgud.io/api/game_stream/send_game_packet",
-  "updatePlayersURL": "https://api.staging.getgud.io/api/player_data/update_players_via_sdk",
-  "sendReportsURL": "https://api.staging.getgud.io/api/report_data/send_reports",
-  "throttleCheckUrl": "https://api.staging.getgud.io/api/game_stream/throttle_match_check",
+  "streamGameURL": "https://api.getgud.io/api/game_stream/send_game_packet",
+  "updatePlayersURL": "https://api.getgud.io/api/player_data/update_players_via_sdk",
+  "sendReportsURL": "https://api.getgud.io/api/report_data/send_reports",
+  "throttleCheckUrl": "https://api.getgud.io/api/game_stream/throttle_match_check",
   "logToFile": true,
   "logFileSizeInBytes": 10000000,
   "circularLogFile": true,

--- a/1-Integrations/Unreal Engine/unreal-engine-integration.md
+++ b/1-Integrations/Unreal Engine/unreal-engine-integration.md
@@ -54,10 +54,10 @@ The `Client_Server_Getgud` project demonstrates how to integrate the GetgudSDK w
 
 ```json
 {
-  "streamGameURL": "https://api.staging.getgud.io/api/game_stream/send_game_packet",
-  "updatePlayersURL": "https://api.staging.getgud.io/api/player_data/update_players_via_sdk",
-  "sendReportsURL": "https://api.staging.getgud.io/api/report_data/send_reports",
-  "throttleCheckUrl": "https://api.staging.getgud.io/api/game_stream/throttle_match_check",
+  "streamGameURL": "https://api.getgud.io/api/game_stream/send_game_packet",
+  "updatePlayersURL": "https://api.getgud.io/api/player_data/update_players_via_sdk",
+  "sendReportsURL": "https://api.getgud.io/api/report_data/send_reports",
+  "throttleCheckUrl": "https://api.getgud.io/api/game_stream/throttle_match_check",
   "logToFile": true,
   "logFileSizeInBytes": 10000000,
   "circularLogFile": true,

--- a/3-Extra/c-integration.md
+++ b/3-Extra/c-integration.md
@@ -463,10 +463,10 @@ Example of configuration file `config.json`:
 
 ```json
 {
-  "streamGameURL": "https://api.staging.getgud.io/api/game_stream/send_game_packet",
-  "updatePlayersURL": "https://api.staging.getgud.io/api/player_data/update_players_via_sdk",
-  "sendReportsURL": "https://api.staging.getgud.io/api/report_data/send_reports",
-  "throttleCheckUrl": "https://api.staging.getgud.io/api/game_stream/throttle_match_check",
+  "streamGameURL": "https://api.getgud.io/api/game_stream/send_game_packet",
+  "updatePlayersURL": "https://api.getgud.io/api/player_data/update_players_via_sdk",
+  "sendReportsURL": "https://api.getgud.io/api/report_data/send_reports",
+  "throttleCheckUrl": "https://api.getgud.io/api/game_stream/throttle_match_check",
   "logToFile": true,
   "logFileSizeInBytes": 10000000,
   "circularLogFile": true,

--- a/3-Extra/csharp-integration.md
+++ b/3-Extra/csharp-integration.md
@@ -434,10 +434,10 @@ Example of configuration file `config.json`:
 
 ```json
 {
-  "streamGameURL": "https://api.staging.getgud.io/api/game_stream/send_game_packet",
-  "updatePlayersURL": "https://api.staging.getgud.io/api/player_data/update_players_via_sdk",
-  "sendReportsURL": "https://api.staging.getgud.io/api/report_data/send_reports",
-  "throttleCheckUrl": "https://api.staging.getgud.io/api/game_stream/throttle_match_check",
+  "streamGameURL": "https://api.getgud.io/api/game_stream/send_game_packet",
+  "updatePlayersURL": "https://api.getgud.io/api/player_data/update_players_via_sdk",
+  "sendReportsURL": "https://api.getgud.io/api/report_data/send_reports",
+  "throttleCheckUrl": "https://api.getgud.io/api/game_stream/throttle_match_check",
   "logToFile": true,
   "logFileSizeInBytes": 10000000,
   "circularLogFile": true,

--- a/3-Extra/python-integration.md
+++ b/3-Extra/python-integration.md
@@ -356,10 +356,10 @@ Example of configuration file `config.json`:
 
 ```json
 {
-  "streamGameURL": "https://api.staging.getgud.io/api/game_stream/send_game_packet",
-  "updatePlayersURL": "https://api.staging.getgud.io/api/player_data/update_players_via_sdk",
-  "sendReportsURL": "https://api.staging.getgud.io/api/report_data/send_reports",
-  "throttleCheckUrl": "https://api.staging.getgud.io/api/game_stream/throttle_match_check",
+  "streamGameURL": "https://api.getgud.io/api/game_stream/send_game_packet",
+  "updatePlayersURL": "https://api.getgud.io/api/player_data/update_players_via_sdk",
+  "sendReportsURL": "https://api.getgud.io/api/report_data/send_reports",
+  "throttleCheckUrl": "https://api.getgud.io/api/game_stream/throttle_match_check",
   "logToFile": true,
   "logFileSizeInBytes": 10000000,
   "circularLogFile": true,

--- a/sdk-commands.md
+++ b/sdk-commands.md
@@ -533,10 +533,10 @@ Example of configuration file `config.json`:
 
 ```json
 {
-  "streamGameURL": "https://api.staging.getgud.io/api/game_stream/send_game_packet",
-  "updatePlayersURL": "https://api.staging.getgud.io/api/player_data/update_players_via_sdk",
-  "sendReportsURL": "https://api.staging.getgud.io/api/report_data/send_reports",
-  "throttleCheckUrl": "https://api.staging.getgud.io/api/game_stream/throttle_match_check",
+  "streamGameURL": "https://api.getgud.io/api/game_stream/send_game_packet",
+  "updatePlayersURL": "https://api.getgud.io/api/player_data/update_players_via_sdk",
+  "sendReportsURL": "https://api.getgud.io/api/report_data/send_reports",
+  "throttleCheckUrl": "https://api.getgud.io/api/game_stream/throttle_match_check",
   "logToFile": true,
   "logFileSizeInBytes": 10000000,
   "circularLogFile": true,


### PR DESCRIPTION
## Summary
- Replace all `api.staging.getgud.io` URLs with `api.getgud.io` across all integration guides and SDK commands docs